### PR TITLE
Ignore invalid URL params

### DIFF
--- a/src/components/pages/tutorial/cards/allCards.tsx
+++ b/src/components/pages/tutorial/cards/allCards.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { wordsPage } from '../const';
 import { IWord } from '../types';
 import Card from './card';
@@ -16,11 +16,25 @@ export default function AllCards() {
   const curGroup = +group - 1;
   const curPage = +page - 1;
 
+  const navigate = useNavigate();
+
   async function fetchWords(): Promise<void> {
-    setLoading(true);
-    const response = await fetch(wordsPage(curGroup, curPage));
-    setWordsInfo(await response.json());
-    setLoading(false);
+    if (curGroup >= 0 && curGroup < 6 && curPage >= 0 && curPage < 30) {
+      if (Number.isInteger(curGroup) && Number.isInteger(curPage)) {
+        setLoading(true);
+        const response = await fetch(wordsPage(curGroup, curPage));
+        setWordsInfo(await response.json());
+        setLoading(false);
+      } else {
+        navigate(`../../glossary/${Math.floor(curGroup) + 1}/${Math.floor(curPage) + 1}`);
+      }
+    } else if (curGroup >= 0 && curGroup < 6) {
+      navigate(`../../glossary/${Math.floor(curGroup) + 1}/1`);
+    } else if (curPage >= 0 && curPage < 30) {
+      navigate(`../../glossary/1/${Math.floor(curPage) + 1}`);
+    } else {
+      navigate('../../glossary/1/1');
+    }
   }
 
   useEffect(() => {

--- a/src/components/pages/tutorial/tutorial.css
+++ b/src/components/pages/tutorial/tutorial.css
@@ -109,7 +109,7 @@
   font-size: 24px;
   border: none;
   outline: none;
-  width: 65px;
+  width: 85px;
   text-align: center;
   background: none;
 }

--- a/src/components/pages/tutorial/tutorial.tsx
+++ b/src/components/pages/tutorial/tutorial.tsx
@@ -22,6 +22,7 @@ export default function TutorialContent() {
   const navigate = useNavigate();
 
   function switchPageInput(e: React.FocusEvent<HTMLInputElement, Element>) {
+    e.preventDefault();
     let value = parseInt(e.target.value, 10);
     if (value <= 1) {
       value = 1;


### PR DESCRIPTION
Исправил недочет, когда при вводе в адресную строку неверных номеров страницы или группы в словаре оно не выдавало данные. 
Теперь в таких ситуация будет происходить перенаправления на верные страницы в зависимости от адреса URL:
- если страница введена не верна а группа верна, перейдёт на 1 группу учебника на указанную страницу
- если группа введена верно, то перейдет на эту группу и первую страницу учебника
- если группа или страница дробные числа - округлит и перейдет на страницу
- если группа и страница не верные, перейдет на 1 группу и 1 страницу